### PR TITLE
Improved Music Playback Display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 __pycache__/
 data/dashboard_message_id.json
+/.venv


### PR DESCRIPTION
## Description
Enhanced the display formatting for music tracks in the PlexWatch dashboard to show more relevant information and fix incorrect display patterns.

### Changes
- Added proper music track detection and formatting
- Fixed episode notation being incorrectly shown for music tracks
- Added music-specific quality information display (bit depth and sample rate)
- Added music note emoji (🎵) for music tracks
- Improved bitrate display for audio streams

### Before
📺 Love and Death - S01E05 | User
└─ [▓▓▓░░░░░░░] 13.8% | 00:32/03:52
└─ ⏯️ Nonep 1.0 Mbps | Plexamp


### After
🎵 Artist Name - Track Title | User
└─ [▓▓▓░░░░░░░] 13.8% | 00:32/03:52
└─ ⏯️ 24bit 48kHz 320 Kbps | Plexamp

### Example
![Discord_JjBgnetyt5](https://github.com/user-attachments/assets/e10ab70a-7418-4a8e-ae76-2e2afa97d366)


## Testing
- Tested with various music tracks
- Verified correct display of:
  - Artist and track names
  - Audio quality information
  - Progress bar and timing
  - Player information


Directly fixes #6 
